### PR TITLE
Fix typo in 'Goal' key and add shebang to parse_data.py

### DIFF
--- a/bd_game.py
+++ b/bd_game.py
@@ -269,7 +269,7 @@ class BdGame:
                 self._game_data['pref'][team]['V'] = np.nan_to_num(pref_table.loc[row_index, 'V'])
                 self._game_data['pref'][team]['VI'] = np.nan_to_num(pref_table.loc[row_index, 'VI'])
                 self._game_data['pref'][team]['VII'] = np.nan_to_num(pref_table.loc[row_index, 'VII'])
-                self._game_data['pref'][team]['Goal'] = np.nan_to_num(pref_table.loc[row_index, 'ЦЕЛЬ'])
+                self._game_data['pref'][team]['Goal'] = np.nan_to_num(pref_table.loc[row_index, 'Цель'])
                 self._game_data['pref'][team]['Points'] = np.nan_to_num(pref_table.loc[row_index, 'Points'])
                 self._game_data['pref'][team]['Penalty'] = np.nan_to_num(pref_table.loc[row_index, 'Penalty'])
                 self._game_data['pref'][team]['Bonus'] = np.nan_to_num(pref_table.loc[row_index, 'Bonus'])

--- a/parse_data.py
+++ b/parse_data.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import argparse
 import os
 from bd_game import BdGame


### PR DESCRIPTION
This pull request introduces a minor fix and a small improvement to the codebase. The main change corrects a key name in the preferences parsing logic to ensure proper data extraction, and a shebang line is added for improved script execution.

- Data parsing fix:
  * Corrected the column name from `'ЦЕЛЬ'` to `'Цель'` in the preferences parsing logic within the `_parse_pref` method of `bd_game.py`, ensuring the correct column is accessed for team goals.

- Script usability:
  * Added a shebang line (`#!/usr/bin/env python3`) at the top of `parse_data.py` to allow the script to be run directly from the command line.