### PR TITLE
feat: add split-pane AI report preview

### DIFF
--- a/webreport/backend/agents/report_agents.py
+++ b/webreport/backend/agents/report_agents.py
@@ -14,6 +14,8 @@ from textwrap import dedent
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+_MIN_TOP_TEAMS_LIMIT = 1
+_MAX_TOP_TEAMS_LIMIT = 1024
 
 # No need to add path, services is in same app
 from services.game_data_service import GameDataService
@@ -284,9 +286,15 @@ class ReportAgentSystem:
             }
 
         elif top_teams_match := re.search(r"топ\s*(\d+)?\s+команд", message_lower):
+            requested_limit = int(top_teams_match.group(1) or 10)
             return {
                 "method": "get_top_teams",
-                "params": {"limit": int(top_teams_match.group(1) or 10)},
+                "params": {
+                    "limit": min(
+                        _MAX_TOP_TEAMS_LIMIT,
+                        max(_MIN_TOP_TEAMS_LIMIT, requested_limit),
+                    )
+                },
                 "description": "Get top teams by total points",
             }
 

--- a/webreport/backend/agents/report_agents.py
+++ b/webreport/backend/agents/report_agents.py
@@ -286,7 +286,12 @@ class ReportAgentSystem:
             }
 
         elif top_teams_match := re.search(r"топ\s*(\d+)?\s+команд", message_lower):
-            requested_limit = int(top_teams_match.group(1) or 10)
+            requested_limit_text = (top_teams_match.group(1) or "10").lstrip("0") or "0"
+            requested_limit = (
+                _MAX_TOP_TEAMS_LIMIT
+                if len(requested_limit_text) > len(str(_MAX_TOP_TEAMS_LIMIT))
+                else int(requested_limit_text)
+            )
             return {
                 "method": "get_top_teams",
                 "params": {

--- a/webreport/backend/agents/report_agents.py
+++ b/webreport/backend/agents/report_agents.py
@@ -7,6 +7,7 @@ import os
 import sys
 import importlib
 import logging
+import re
 from datetime import datetime, date
 import json
 from textwrap import dedent
@@ -282,11 +283,18 @@ class ReportAgentSystem:
                 "description": "Get summary of all games",
             }
 
-        elif "топ команд" in message_lower or "top teams" in message_lower:
+        elif top_teams_match := re.search(r"топ\s*(\d+)?\s+команд", message_lower):
+            return {
+                "method": "get_top_teams",
+                "params": {"limit": int(top_teams_match.group(1) or 10)},
+                "description": "Get top teams by total points",
+            }
+
+        elif "top teams" in message_lower:
             return {
                 "method": "get_top_teams",
                 "params": {"limit": 10},
-                "description": "Get top 10 teams by total points",
+                "description": "Get top teams by total points",
             }
 
         elif any(

--- a/webreport/backend/test_top_team_limit.py
+++ b/webreport/backend/test_top_team_limit.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from agents.report_agents import ReportAgentSystem
+from services.game_data_service import GameDataService
+
+
+class TopTeamLimitTest(unittest.TestCase):
+    def test_fallback_clamps_requested_top_team_limit(self) -> None:
+        service = object.__new__(GameDataService)
+        limits: list[int] = []
+
+        def record_limit(limit: int = 10) -> list[object]:
+            limits.append(limit)
+            return []
+
+        system = ReportAgentSystem(service=service)
+        system.agents_available = False
+
+        with patch.object(GameDataService, "get_top_teams", side_effect=record_limit):
+            oversized_response = system.process_user_request("топ 1000000 команд")
+            zero_response = system.process_user_request("топ 0 команд")
+
+        self.assertTrue(oversized_response["success"])
+        self.assertTrue(zero_response["success"])
+        self.assertEqual([1024, 1], limits)
+
+
+if __name__ == "__main__":
+    _ = unittest.main()

--- a/webreport/backend/test_top_team_limit.py
+++ b/webreport/backend/test_top_team_limit.py
@@ -27,6 +27,31 @@ class TopTeamLimitTest(unittest.TestCase):
         self.assertTrue(zero_response["success"])
         self.assertEqual([1024, 1], limits)
 
+    def test_fallback_skips_int_for_oversized_top_team_limit(self) -> None:
+        service = object.__new__(GameDataService)
+        limits: list[int] = []
+
+        def record_limit(limit: int = 10) -> list[object]:
+            limits.append(limit)
+            return []
+
+        system = ReportAgentSystem(service=service)
+        system.agents_available = False
+        oversized_limit = "9" * 10_000
+
+        with (
+            patch.object(GameDataService, "get_top_teams", side_effect=record_limit),
+            patch(
+                "agents.report_agents.int",
+                side_effect=AssertionError("oversized limits must not be parsed"),
+                create=True,
+            ),
+        ):
+            response = system.process_user_request(f"топ {oversized_limit} команд")
+
+        self.assertTrue(response["success"])
+        self.assertEqual([1024], limits)
+
 
 if __name__ == "__main__":
     _ = unittest.main()

--- a/webreport/frontend/chat_pane.py
+++ b/webreport/frontend/chat_pane.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+from uuid import uuid4
+
+import streamlit as st
+
+
+def render_chat_pane(clear_conversation: Callable[[], None]) -> None:
+    header, fullscreen = st.columns([12, 1])
+    with header:
+        st.subheader("💬 Разговор с AI-агентом")
+    with fullscreen:
+        suffix = " •" if st.session_state.report_ready_badge else ""
+        if st.button(f"⛶{suffix}", key="fullscreen_chat", help="Развернуть чат"):
+            st.session_state.fullscreen = None if st.session_state.fullscreen == "chat" else "chat"
+            st.session_state.report_ready_badge = False
+            st.rerun()
+
+    if st.session_state.api_available:
+        st.caption("API подключен")
+    else:
+        st.caption("API недоступен. Ошибки запросов появятся в истории чата.")
+
+    with st.form(key="chat_form", clear_on_submit=True):
+        user_input = st.text_area(
+            "Ваше сообщение",
+            height=60,
+            placeholder="Опишите нужный отчёт...",
+        )
+        send, clear = st.columns(2)
+        with send:
+            submit = st.form_submit_button("Отправить", use_container_width=True)
+        with clear:
+            clear_requested = st.form_submit_button("🗑️ Очистить чат", use_container_width=True)
+
+    if clear_requested:
+        clear_conversation()
+        st.rerun()
+    if submit and user_input.strip():
+        _queue_request(user_input.strip())
+        st.rerun()
+
+    selected_request_id = _selected_request_id()
+    with st.container(height=520, key="chat-pane-scroll", border=False, autoscroll=True):
+        if not st.session_state.chat_history:
+            st.info("История диалога пуста. Начните с запроса к данным игр.")
+        for message in st.session_state.chat_history:
+            _render_message(message, selected_request_id)
+
+
+def process_pending_request(send_message: Callable[[str], dict[str, object]]) -> None:
+    pending = st.session_state.pending_request
+    if pending is None:
+        return
+
+    response = send_message(pending["content"])
+    st.session_state.pending_request = None
+    st.session_state.is_generating = False
+    assistant_message = {
+        "id": str(uuid4()),
+        "role": "assistant",
+        "content": _response_text(response),
+        "timestamp": datetime.now().isoformat(),
+        "request_id": pending["id"],
+    }
+    if response.get("success") is True:
+        report_id = str(uuid4())
+        assistant_message["report"] = {
+            "id": report_id,
+            "request_id": pending["id"],
+            "request_text": pending["content"],
+            "title": _response_text(response),
+            "data": response.get("data"),
+        }
+        st.session_state.active_report_id = report_id
+        if st.session_state.fullscreen == "chat":
+            st.session_state.report_ready_badge = True
+        elif not st.session_state.user_has_dragged:
+            st.session_state.split_pct = 50.0
+    else:
+        assistant_message["error"] = _response_text(response, "Не удалось создать отчёт")
+    st.session_state.chat_history.append(assistant_message)
+    st.rerun()
+
+
+def _queue_request(content: str) -> None:
+    request = {
+        "id": str(uuid4()),
+        "role": "user",
+        "content": content,
+        "timestamp": datetime.now().isoformat(),
+    }
+    st.session_state.chat_history.append(request)
+    st.session_state.pending_request = request
+    st.session_state.is_generating = True
+
+
+def _render_message(message: dict[str, object], selected_request_id: str | None) -> None:
+    role = message.get("role")
+    message_id = message.get("id")
+    is_active_request = role == "user" and message_id == selected_request_id
+    container = (
+        st.container(key=f"active-request-{message_id}", border=False)
+        if is_active_request and isinstance(message_id, str)
+        else st.container()
+    )
+    with container:
+        with st.chat_message("user" if role == "user" else "assistant"):
+            content = message.get("content")
+            st.markdown(content if isinstance(content, str) else "")
+            if is_active_request:
+                st.caption("Этот запрос открыт в области отчёта.")
+            report = message.get("report")
+            if role == "assistant" and isinstance(report, dict):
+                report_id = report.get("id")
+                if isinstance(report_id, str):
+                    label = "Отчёт открыт" if report_id == st.session_state.active_report_id else "Открыть этот отчёт"
+                    if st.button(label, key=f"open_report_{report_id}", use_container_width=True):
+                        st.session_state.active_report_id = report_id
+                        st.session_state.report_ready_badge = False
+                        st.rerun()
+            error = message.get("error")
+            if isinstance(error, str):
+                st.error(error)
+
+
+def _selected_request_id() -> str | None:
+    for message in st.session_state.chat_history:
+        report = message.get("report")
+        if not isinstance(report, dict) or report.get("id") != st.session_state.active_report_id:
+            continue
+        request_id = report.get("request_id")
+        return request_id if isinstance(request_id, str) else None
+    return None
+
+
+def _response_text(response: dict[str, object], fallback: str = "Отчёт готов") -> str:
+    value = response.get("message")
+    if isinstance(value, str) and value:
+        return value
+    value = response.get("error")
+    if isinstance(value, str) and value:
+        return value
+    return fallback

--- a/webreport/frontend/main.py
+++ b/webreport/frontend/main.py
@@ -124,7 +124,11 @@ def send_chat_message(message: str) -> dict[str, object]:
         }
     if isinstance(payload, dict):
         return payload
-    return {"success": False, "error": "Сервер вернул некорректный ответ."}
+    return {
+        "success": False,
+        "error": "Сервер вернул некорректный ответ.",
+        "message": "Сервер вернул некорректный ответ.",
+    }
 
 
 def clear_conversation() -> None:

--- a/webreport/frontend/main.py
+++ b/webreport/frontend/main.py
@@ -114,7 +114,14 @@ def send_chat_message(message: str) -> dict[str, object]:
             "error": str(error),
             "message": "Не удалось связаться с сервером.",
         }
-    payload: object = response.json()
+    try:
+        payload: object = response.json()
+    except requests.exceptions.JSONDecodeError:
+        return {
+            "success": False,
+            "error": "Сервер вернул некорректный ответ.",
+            "message": "Сервер вернул некорректный ответ.",
+        }
     if isinstance(payload, dict):
         return payload
     return {"success": False, "error": "Сервер вернул некорректный ответ."}

--- a/webreport/frontend/main.py
+++ b/webreport/frontend/main.py
@@ -1,339 +1,170 @@
-"""
-Streamlit frontend for the web reporting system.
-Provides UI with chat and report views.
-"""
-import streamlit as st
-import requests
-import pandas as pd
-import json
-from datetime import datetime
-from typing import Dict, Any, Optional, List
 import os
 import uuid
 
-# Configuration
+import requests
+import streamlit as st
+
+from chat_pane import process_pending_request, render_chat_pane
+from report_pane import render_report_pane
+from split_pane import render_split_pane_controller
+
+
 API_BASE_URL = os.getenv("API_BASE_URL", "http://localhost:8000")
 
-# Page configuration
 st.set_page_config(
     page_title="Game Data Reports",
     page_icon="🎮",
     layout="wide",
-    initial_sidebar_state="expanded"
+    initial_sidebar_state="collapsed",
 )
 
-# Custom CSS
-st.markdown("""
-<style>
-    .main-header {
-        font-size: 2.5rem;
-        font-weight: bold;
-        color: #1E88E5;
-        margin-bottom: 1rem;
-    }
-    .chat-message {
-        padding: 1rem;
-        border-radius: 0.5rem;
-        margin-bottom: 0.5rem;
-    }
-    .user-message {
-        background-color: #E3F2FD;
-        border-left: 4px solid #1E88E5;
-    }
-    .assistant-message {
-        background-color: #F5F5F5;
-        border-left: 4px solid #757575;
-    }
-    .report-section {
-        background-color: #FFFFFF;
-        padding: 1.5rem;
-        border-radius: 0.5rem;
-        box-shadow: 0 2px 4px rgba(0,0,0,0.1);
-    }
-</style>
-""", unsafe_allow_html=True)
+st.markdown(
+    """
+    <style>
+        [data-testid="stAppViewContainer"], [data-testid="stMain"] {
+            overflow: hidden;
+        }
+        [data-testid="stMainBlockContainer"] {
+            max-width: none;
+            padding-bottom: 0;
+        }
+        .st-key-chat-pane-scroll, .st-key-report-pane-scroll {
+            overflow: auto;
+        }
+        .st-key-report-pane-scroll {
+            position: relative;
+        }
+        [class*="st-key-active-request"] {
+            background: color-mix(in srgb, #1E88E5 14%, transparent);
+            border-left: 0.25rem solid #1E88E5;
+            border-radius: 0.5rem;
+            padding: 0.25rem 0.5rem;
+        }
+        .report-loading-overlay {
+            align-items: center;
+            background: rgba(255, 255, 255, 0.7);
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+            inset: 0;
+            justify-content: center;
+            position: absolute;
+            z-index: 10;
+        }
+        .report-loading-spinner {
+            animation: report-spin 0.8s linear infinite;
+            border: 0.25rem solid rgba(30, 136, 229, 0.2);
+            border-radius: 50%;
+            border-top-color: #1E88E5;
+            height: 2rem;
+            width: 2rem;
+        }
+        @keyframes report-spin {
+            to { transform: rotate(360deg); }
+        }
+        @media (max-width: 768px) {
+            [data-testid="stMainBlockContainer"] {
+                padding-left: 0.75rem;
+                padding-right: 0.75rem;
+            }
+        }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 
-def init_session_state():
-    """Initialize session state variables."""
-    if 'session_id' not in st.session_state:
-        st.session_state.session_id = str(uuid.uuid4())
-    if 'view' not in st.session_state:
-        st.session_state.view = 'chat'
-    if 'chat_history' not in st.session_state:
-        st.session_state.chat_history = []
-    if 'current_report' not in st.session_state:
-        st.session_state.current_report = None
-    if 'report_data' not in st.session_state:
-        st.session_state.report_data = None
+def init_session_state() -> None:
+    defaults = {
+        "session_id": str(uuid.uuid4()),
+        "chat_history": [],
+        "active_report_id": None,
+        "split_pct": 65.0,
+        "user_has_dragged": False,
+        "fullscreen": None,
+        "report_ready_badge": False,
+        "pending_request": None,
+        "is_generating": False,
+        "api_available": False,
+    }
+    for name, value in defaults.items():
+        if name not in st.session_state:
+            st.session_state[name] = value
 
 
 def check_api_health() -> bool:
-    """Check if API is available."""
     try:
         response = requests.get(f"{API_BASE_URL}/health", timeout=2)
-        return response.status_code == 200
-    except requests.exceptions.RequestException:
+    except requests.RequestException:
         return False
+    return response.status_code == 200
 
 
-def send_chat_message(message: str) -> Dict[str, Any]:
-    """Send chat message to API."""
+def send_chat_message(message: str) -> dict[str, object]:
     try:
         response = requests.post(
             f"{API_BASE_URL}/api/chat",
             json={"message": message, "session_id": st.session_state.session_id},
-            timeout=30
+            timeout=30,
         )
         response.raise_for_status()
-        return response.json()
-    except Exception as e:
+    except requests.RequestException as error:
         return {
             "success": False,
-            "error": str(e),
-            "message": "Failed to communicate with backend"
+            "error": str(error),
+            "message": "Не удалось связаться с сервером.",
         }
+    payload: object = response.json()
+    if isinstance(payload, dict):
+        return payload
+    return {"success": False, "error": "Сервер вернул некорректный ответ."}
 
 
-def get_conversation_history() -> List[Dict[str, Any]]:
-    """Get conversation history from API."""
+def clear_conversation() -> None:
     try:
-        response = requests.get(
-            f"{API_BASE_URL}/api/history/{st.session_state.session_id}",
-            timeout=10
+        response = requests.post(
+            f"{API_BASE_URL}/api/clear/{st.session_state.session_id}",
+            timeout=10,
         )
         response.raise_for_status()
-        data = response.json()
-        return data.get("history", [])
-    except requests.exceptions.RequestException:
-        return []
+    except requests.RequestException as error:
+        st.warning(f"Не удалось очистить историю на сервере: {error}")
+    st.session_state.chat_history = []
+    st.session_state.active_report_id = None
+    st.session_state.pending_request = None
+    st.session_state.is_generating = False
+    st.session_state.report_ready_badge = False
+    st.session_state.split_pct = 65.0
+    st.session_state.user_has_dragged = False
 
 
-def clear_conversation():
-    """Clear conversation history."""
-    try:
-        requests.post(f"{API_BASE_URL}/api/clear/{st.session_state.session_id}", timeout=10)
-        st.session_state.chat_history = []
-        st.session_state.current_report = None
-        st.session_state.report_data = None
-    except Exception as e:
-        st.error(f"Failed to clear history: {e}")
+def rerun_page() -> None:
+    st.rerun()
 
 
-def render_chat_view():
-    """Render the chat view."""
-    st.markdown('<div class="main-header">💬 Чат с AI-агентом</div>', unsafe_allow_html=True)
-
-    # Chat interface
-    st.markdown("### Опишите требования к отчёту")
-    st.markdown("*Например: 'покажи все игры', 'топ 10 команд', 'статистика команды X'*")
-
-    # Chat input
-    with st.form(key='chat_form', clear_on_submit=True):
-        user_input = st.text_area(
-            "Ваше сообщение:",
-            height=100,
-            placeholder="Введите требования к отчёту..."
-        )
-        col1, col2 = st.columns([1, 5])
-        with col1:
-            submit_button = st.form_submit_button("Отправить", use_container_width=True)
-        with col2:
-            clear_button = st.form_submit_button("Очистить историю", use_container_width=True)
-
-    if clear_button:
-        clear_conversation()
-        st.rerun()
-
-    if submit_button and user_input:
-        with st.spinner('Генерация отчёта...'):
-            # Add user message to history
-            st.session_state.chat_history.append({
-                "role": "user",
-                "content": user_input,
-                "timestamp": datetime.now().isoformat()
-            })
-
-            # Send to API
-            response = send_chat_message(user_input)
-
-            # Add response to history
-            st.session_state.chat_history.append({
-                "role": "assistant",
-                "content": response,
-                "timestamp": datetime.now().isoformat()
-            })
-
-            # Update current report
-            if response.get("success"):
-                st.session_state.current_report = response.get("message")
-                st.session_state.report_data = response.get("data")
-                st.success("✅ Отчёт сгенерирован! Переключитесь на вкладку 'Отчёт' для просмотра.")
-            else:
-                st.error(f"❌ Ошибка: {response.get('error', 'Unknown error')}")
-
-            st.rerun()
-
-    # Display chat history
-    st.markdown("---")
-    st.markdown("### История диалога")
-
-    if not st.session_state.chat_history:
-        st.info("История диалога пуста. Начните новый диалог выше.")
-    else:
-        for msg in reversed(st.session_state.chat_history[-10:]):  # Show last 10 messages
-            role = msg.get("role", "unknown")
-            content = msg.get("content", "")
-            timestamp = msg.get("timestamp", "")
-
-            if role == "user":
-                st.markdown(f'<div class="chat-message user-message">', unsafe_allow_html=True)
-                st.markdown(f"**👤 Пользователь** *({timestamp[:19]})*")
-                st.markdown(f"{content}")
-                st.markdown('</div>', unsafe_allow_html=True)
-            else:
-                st.markdown(f'<div class="chat-message assistant-message">', unsafe_allow_html=True)
-                st.markdown(f"**🤖 Ассистент** *({timestamp[:19]})*")
-                if isinstance(content, dict):
-                    if content.get("success"):
-                        st.markdown(f"✅ {content.get('message', 'Отчёт готов')}")
-                    else:
-                        st.markdown(f"❌ {content.get('error', 'Ошибка')}")
-                else:
-                    st.markdown(f"{content}")
-                st.markdown('</div>', unsafe_allow_html=True)
-
-
-def render_report_view():
-    """Render the report view."""
-    st.markdown('<div class="main-header">📊 Отчёт по данным игр</div>', unsafe_allow_html=True)
-
-    if st.session_state.report_data is None:
-        st.info("📝 Отчёт ещё не сгенерирован. Перейдите в чат и опишите требования к отчёту.")
-
-        # Show some example queries
-        st.markdown("### Примеры запросов:")
-        st.markdown("""
-        - **Все игры**: "покажи все игры"
-        - **Топ команд**: "топ 10 команд по очкам"
-        - **Статистика команды**: "статистика команды [название]"
-        - **Очки команд**: "покажи очки всех команд"
-        """)
-        return
-
-    # Display current report
-    st.markdown(f"### {st.session_state.current_report or 'Текущий отчёт'}")
-
-    try:
-        data = st.session_state.report_data
-
-        if isinstance(data, list) and len(data) > 0:
-            # Convert to DataFrame for better display
-            df = pd.DataFrame(data)
-
-            # Display metrics if available
-            st.markdown("#### Основные показатели")
-            col1, col2, col3 = st.columns(3)
-            with col1:
-                st.metric("Всего записей", len(df))
-            with col2:
-                if 'total_points' in df.columns:
-                    st.metric("Средние очки", f"{df['total_points'].mean():.2f}")
-            with col3:
-                if 'game_date' in df.columns:
-                    st.metric("Уникальных дат", df['game_date'].nunique())
-
-            # Display table
-            st.markdown("#### Данные")
-            st.dataframe(df, use_container_width=True, height=400)
-
-            # Download button
-            csv = df.to_csv(index=False).encode('utf-8')
-            st.download_button(
-                label="📥 Скачать CSV",
-                data=csv,
-                file_name=f"report_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv",
-                mime="text/csv"
-            )
-
-            # Charts if numeric data available
-            numeric_cols = df.select_dtypes(include=['float64', 'int64']).columns.tolist()
-            if numeric_cols and len(df) > 0:
-                st.markdown("#### Визуализация")
-
-                chart_col = st.selectbox("Выберите колонку для графика:", numeric_cols)
-                if chart_col:
-                    st.bar_chart(df.set_index(df.columns[0])[chart_col])
-
-        elif isinstance(data, dict):
-            # Display dict data
-            st.json(data)
-
-        else:
-            st.write(data)
-
-    except Exception as e:
-        st.error(f"Ошибка отображения данных: {e}")
-        st.write("Сырые данные:")
-        st.write(st.session_state.report_data)
-
-
-def main():
-    """Main application."""
+def main() -> None:
     init_session_state()
+    st.session_state.api_available = check_api_health()
 
-    # Sidebar
-    with st.sidebar:
-        st.markdown("## 🎮 Game Data Reports")
-        st.markdown("---")
+    split = st.session_state.split_pct
+    chat_weight = split if isinstance(split, (float, int)) else 65.0
+    report_weight = 100.0 - chat_weight
+    chat_column, report_column = st.columns([chat_weight, report_weight], gap="small")
 
-        # Check API health
-        if check_api_health():
-            st.success("✅ API подключен")
-        else:
-            st.error("❌ API недоступен")
-            st.markdown(f"Проверьте, что сервер запущен на {API_BASE_URL}")
+    with chat_column:
+        st.markdown('<span id="chat-pane-anchor"></span>', unsafe_allow_html=True)
+        render_chat_pane(clear_conversation)
+    with report_column:
+        st.markdown('<span id="report-pane-anchor"></span>', unsafe_allow_html=True)
+        render_report_pane(rerun_page)
 
-        st.markdown("---")
-
-        # View selector
-        st.markdown("### Навигация")
-        view = st.radio(
-            "Выберите представление:",
-            options=['chat', 'report'],
-            format_func=lambda x: '💬 Чат' if x == 'chat' else '📊 Отчёт',
-            key='view_selector'
-        )
-        st.session_state.view = view
-
-        st.markdown("---")
-
-        # Quick actions
-        st.markdown("### Быстрые действия")
-        if st.button("🔄 Обновить", use_container_width=True):
-            st.rerun()
-
-        if st.button("🗑️ Очистить чат", use_container_width=True):
-            clear_conversation()
-            st.rerun()
-
-        st.markdown("---")
-        st.markdown("### О системе")
-        st.markdown("""
-        Эта система использует:
-        - **FastAPI** для REST API
-        - **Streamlit** для UI
-        - **AutoGen** для агентов
-        - **SQLAlchemy** для БД
-        """)
-
-    # Main content
-    if st.session_state.view == 'chat':
-        render_chat_view()
-    else:
-        render_report_view()
+    render_split_pane_controller(
+        chat_weight,
+        st.session_state.fullscreen,
+        st.session_state.is_generating,
+    )
+    process_pending_request(send_chat_message)
 
 
 if __name__ == "__main__":
     main()
-

--- a/webreport/frontend/poetry.lock
+++ b/webreport/frontend/poetry.lock
@@ -50,7 +50,7 @@ version = "26.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
     {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
@@ -86,11 +86,125 @@ version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
     {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
 ]
+
+[[package]]
+name = "cffi"
+version = "2.1.0"
+description = "Foreign Function Interface for Python calling C code."
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "os_name == \"nt\" and implementation_name != \"pypy\""
+files = [
+    {file = "cffi-2.1.0-cp310-cp310-macosx_10_15_x86_64.whl", hash = "sha256:b65f590ef2a44640f9a05dbb548a429b4ade77913ce683ac8b1480777658a6c0"},
+    {file = "cffi-2.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:164bff1657b2a74f0b6d54e11c9b375bc97b931f2ca9c43fcf875838da1570dd"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:c941bb58d5a6e1c3892d86e42927ed6c180302f07e6d395d08c416e594b98b46"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a016194dbe13d14ee9556e734b772d8d67b947092b268d757fd4290e3ba2dfc2"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:03e9810d18c646077e501f661b682fbf5dee4676048527ca3cffe66faa9960dd"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:19c54ac121cad98450b4896fa9a43ee0180d57bc4bc911a33db6cab1efab6cd3"},
+    {file = "cffi-2.1.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d433a51f1870e43a13b6732f92aaf540ff77c2015097c78556f75a2d6c030e0"},
+    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:3d7f118b5adbfdfead90c25822690b02bc8074fba949bb7858bec4ebd55adb43"},
+    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c5f5df567f6eb216de69be06ce55c8b714090fae02b18a3b40da8163b8c5fa9c"},
+    {file = "cffi-2.1.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:11b3fb55f4f8ad92274ed26705f65d8f91457de71f5380061eb6d125a768fecd"},
+    {file = "cffi-2.1.0-cp310-cp310-win32.whl", hash = "sha256:9d72af0cf10a76a600a9690078fe31c63b9588c8e86bf9fd353f713c84b5db0f"},
+    {file = "cffi-2.1.0-cp310-cp310-win_amd64.whl", hash = "sha256:fb62edb5bb52cca65fab91a63afa7561607120d26090a7e8fda6fb9f064726da"},
+    {file = "cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl", hash = "sha256:02cb7ff33ded4f1532476731f89ede53e2e488a8e6205515a82144246ffa7dcc"},
+    {file = "cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f5bce581e6b8c235e566a14768a943b172ada3ed73537bb0c0be1edee312d4e7"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:30b65779d598c370374fefabf138d456fd6f3216bfa7bedfab1ba82025b0cd93"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:88023dfe18799507b73f1dbb0d14326a17465de1bc9c9c7655c22845e9ddc3a2"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:0a96b74cda968eebbad56d973efe5098974f0a9fb323865bf99ea1fd24e3e64c"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:a5781494d4d400a3f47f8f1da94b324f6e6b440a53387774002890a2a2f4b50f"},
+    {file = "cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aa7a1b53a2a4452ada2d1b5dade9960b2522f1e61293a811a077439e39029565"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:9d8272c0e483b024e1b9ad029821470ed8ec65631dbd90217469da0e7cd89f1c"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:7762faa47e8ff7eb80bd261d9a7d8eea2d8baa69de5e95b70c1f338bbe712f02"},
+    {file = "cffi-2.1.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:89095c1968b4ba8285840e131bf2891b09ae137fe2146905acae0354fbce1b5e"},
+    {file = "cffi-2.1.0-cp311-cp311-win32.whl", hash = "sha256:64c753a0f87a256020004f37a1c8c02c480e725f910f0b2a0f3f07debd1b2479"},
+    {file = "cffi-2.1.0-cp311-cp311-win_amd64.whl", hash = "sha256:4f26194e3d95e06501b942642855aed4f953d55e95d7d01b7c4483db3ecff458"},
+    {file = "cffi-2.1.0-cp311-cp311-win_arm64.whl", hash = "sha256:35aaea0c7ee0e58a5cd8c2fd1a48fdf7ece0d2699b7ecdda08194e9ce5dd9b3d"},
+    {file = "cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:df2b82571a1b30f58a87bf4e5a9e78d2b1eff6c6ce8fd3aa3757221f93f0863f"},
+    {file = "cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:78474632761faa0fb96f30b1c928c84ebcf68713cbb80d15bab09dfe61640fde"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:5972433ad71a9e46516584ef60a0fda12d9dc459938d1539c3ddecf9bdc1368d"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b6422532152adf4e59b110cb2808cee7a033800952f5c036b4af047ee43199e7"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:46b1c8db8f6122420f32d02fffb924c2fe9bc772d228c7c711748fff56aabb2b"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9fafc5aa2e2a39aaf7f8cc0c1f044a9b07fca12e558dca53a3cc5c654ad67a7"},
+    {file = "cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1e9f50d192a3e525b15a75ab5114e442d83d657b7ec29182a991bc9a88fd3a66"},
+    {file = "cffi-2.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:98fff996e983a36d3aa2eca83af40c5821202e7e6f32d13ae94e3d2286f10cfe"},
+    {file = "cffi-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:379de10ce1ba048b1448599d1b37b24caee16309d1ac98d3982fc997f768700b"},
+    {file = "cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a"},
+    {file = "cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384"},
+    {file = "cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6"},
+    {file = "cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:10537b1df4967ca26d21e5072d7d54188354483b91dc75058968d3f0cf13fbda"},
+    {file = "cffi-2.1.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a95b05f9baf29b91171b3a8bd2020b028835243e7b0ff6bb23e2a3c228518b1b"},
+    {file = "cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:15faec4adfff450819f3aee0e2e02c812de6edb88203aa58807955db2003472a"},
+    {file = "cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:716ff8ec22f20b4d988b12884086bcef0fc99737043e503f7a3935a6be99b1ea"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:63960549e4f8dc41e31accb97b975abaecfc44c03e396c093a6436763c2ea7db"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3b926723c13eba9f81d2ef3820d63aeceec3b2d4639906047bf675cb8a7a500d"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:47ff3a8bfd8cb9da1af7524b965127095055654c177fcfc7578debcb015eecd0"},
+    {file = "cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224"},
+    {file = "cffi-2.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:961be50688f7fba2fa65f63712d3b9b341a22311f5253460ce933f52f0de1c8c"},
+    {file = "cffi-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:bf5c6cf48238b0eb4c086978c492ad1cbc22373fc5b2d7353b3a598ce6db887a"},
+    {file = "cffi-2.1.0-cp313-cp313-win32.whl", hash = "sha256:db3eb7d46527159a878ec3460e9d40615bc25ba337d477db681aea6e4f05c5d2"},
+    {file = "cffi-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:8e74a6135550c4748af665b1b1118b6aab33b1fc6a16f9aff630af107c3b4512"},
+    {file = "cffi-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:2282cd5e38aa8accd03e99d1256af8411c84cdbee6a89d841b563fdbd1f3e50f"},
+    {file = "cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:d2117334c3af3bdcb9a88522b844a2bdb5efdc4f71c6c822df55486ae1c3347a"},
+    {file = "cffi-2.1.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:702c436735fbe99d59ada02a1f65cfc0d31c0ee8b7290912f8fbc5cd1e4b16c3"},
+    {file = "cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:1ff3456eab0d889592d1936d6125bbfbc7ae4d3354a700f8bd80450a66445d4d"},
+    {file = "cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c4165821e131d6d4ca444347c2b694e2311bcfa3fe5a861cc72968f28867beac"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:276f20fffd7b396e12516ba8edf9509210ac248cbbc5acbc39cd512f9f59ebe6"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7d5980a3433d4b71a5e120f9dd551403d7824e31e2e67124fe2769c404c06913"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6ca4919c6e4f89aa99c42510b42cf54596892c00b3f9077f6bdd1505e24b9c8d"},
+    {file = "cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d53d10f7da99ae46f7373b9150393e9c5eab9b224909982b43832668de4779f5"},
+    {file = "cffi-2.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c351efb95e832a853a29361675f33a7ce53de1a109cd73fd47af0712213aa4ce"},
+    {file = "cffi-2.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:dbf7c7a88e2bac086f06d14577332760bdeecc42bdec8ac4077f6260557d9326"},
+    {file = "cffi-2.1.0-cp314-cp314-win32.whl", hash = "sha256:1854b724d00f6654c742097d5387569021be12d3a0f770eae1df8f8acfcc6acd"},
+    {file = "cffi-2.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:1b96bfe2c4bd825681b7d311ad6d9b7280a091f43e8f63da5729638083cd3bfb"},
+    {file = "cffi-2.1.0-cp314-cp314-win_arm64.whl", hash = "sha256:7d28dff1db6764108bc30788d85d61c876beff416d9a49cb9dd7c5a9f34f5804"},
+    {file = "cffi-2.1.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:7ea6b3e2c4250ff1de21c630fe72d0f63eb95c2c32ffbf64a358cf4a8836d714"},
+    {file = "cffi-2.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6af371f3767faeffc6ac1ef57cdfd25844403e9d3f476c5537caee499de96376"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:eb4e8997a49aa2c08a3e43c9045d224448b8941d88e7ac163c7d383e560cbf98"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:bf01d8c84cbea96b944c73b22182e6c7c432b3475632b8111dbfdc95ddad6e13"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:33eb1ad83ebe8f313e0df035c406227d55a79456704a863fad9842136af5ad7d"},
+    {file = "cffi-2.1.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ac0f1a2d0cfa7eea3f2aaf006ab6e70e8feeb16b75d65b7e5939982ca2f11056"},
+    {file = "cffi-2.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c16914df9fb7f500e440e6875fa23ff5e0b31db01fa9c06af98d59a91f0dc2e4"},
+    {file = "cffi-2.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5ecbd0499275d57506d397eebe1981cee87b47fcd9ef5c22cab7ed7644a39a94"},
+    {file = "cffi-2.1.0-cp314-cp314t-win32.whl", hash = "sha256:7d034dcffa09e9a46c93fa3a3be402096cb5354ac6e41ab8e5cc9cd8b642ad76"},
+    {file = "cffi-2.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0582a58f3051372229ca8e7f5f589f9e5632678208d8636fea3676711fdf7fe5"},
+    {file = "cffi-2.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:510aeeeac94811b138077451da1fb18b308a5feab47dd2b603af55804155e1c8"},
+    {file = "cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphoneos.whl", hash = "sha256:2e9dabb9abcb7ad15938c7196ad5c1718a4e6d33cc79b4c0209bdb64c4a54a5c"},
+    {file = "cffi-2.1.0-cp315-cp315-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:37f525a7e7e50c017fdebe58b787be310ad59357ae43a053943a6e1a6c526001"},
+    {file = "cffi-2.1.0-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:95f2954c2c9473d892eca6e0409f3568b37ab62a8eedb122461f73cc273476e3"},
+    {file = "cffi-2.1.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:cdf2448aab5f661c9315308ec8b93f4e8a1a67a3c733f8631067a2b67d5913dc"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:90bec57cf82089383bd06a605b3eb8daebf7e5a668520beaf6e327a83a947699"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6274dcb2d15cef48daa73ed1be5a40d501d74dccd0cd6db364776d12cb6ba022"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:2b71d409cccee78310ab5dec549aed052aaea483346e282c7b02362596e01bb0"},
+    {file = "cffi-2.1.0-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7d3538f9c0e50670f4deb93dbb696576e60590369cae2faf7de681e597a8a1f1"},
+    {file = "cffi-2.1.0-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:8f9ec95b8a043d3dfbc74d9abc6f7baf524dd27a8dc160b0a32ff9cdab650c28"},
+    {file = "cffi-2.1.0-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:af5e2915d41fe6c961694d7bfdc8562942638200f3ce2765dfb8b745cf997629"},
+    {file = "cffi-2.1.0-cp315-cp315-win32.whl", hash = "sha256:0a42c688d19fca6e095a53c6a6e2295a5b050a8b289f109adab02a9e61a25de6"},
+    {file = "cffi-2.1.0-cp315-cp315-win_amd64.whl", hash = "sha256:bccbbb5ee76a61f9d99b5bf3846a51d7fca4b6a732fe46f89295610edaf41853"},
+    {file = "cffi-2.1.0-cp315-cp315-win_arm64.whl", hash = "sha256:8d35c139744adb3e727cd51b1a18324bbe44b8bd41bf8322bca4d41289f48eda"},
+    {file = "cffi-2.1.0-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:f9912624a0c0b834b7520d7769b3644453aabc0a7e1c839da7359f050750e9bc"},
+    {file = "cffi-2.1.0-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:df92f2aba50eb4d96718b68ef76f2e57a57b54f2fa62333496d16c6d585a85ca"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:0520e1f4c35f44e209cbbb421b67eec42e6a157f59444dfb6058874ff3610e5d"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:3681e031db29958a7502f5c0c9d6bbc4c36cb20f7b104086fa642d1799631ff8"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:762f99479dcb369f60ab9017ad4ab97a36a1dd7c1ee5a3b15db0f4b8659120cd"},
+    {file = "cffi-2.1.0-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0611e7ebf90573a535ebdc33ae9da222d037853983e13359f580fab781ca017f"},
+    {file = "cffi-2.1.0-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:86cf8755a791f72c85dc287128cc62d4f24d392e3f1e15837245623f4a33cccc"},
+    {file = "cffi-2.1.0-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:ba00f661f8ba35d075c937174e27c2c421cec3942fd2e0ea3e66996757c0fdd9"},
+    {file = "cffi-2.1.0-cp315-cp315t-win32.whl", hash = "sha256:cb96698e3c7413d906ce83f8ffd245ec1bd94707541f299d0ce4d6b0193e982b"},
+    {file = "cffi-2.1.0-cp315-cp315t-win_amd64.whl", hash = "sha256:f146d154428a2523f9cc7936c02353c2459b8f6cf07d3cd1ee1c0a611109c5d5"},
+    {file = "cffi-2.1.0-cp315-cp315t-win_arm64.whl", hash = "sha256:cbb7640ce37159548d2147b5b8c241f962143d4c71231431820783f4dc78f210"},
+    {file = "cffi-2.1.0.tar.gz", hash = "sha256:efc1cdd798b1aaf39b4610bba7aad28c9bea9b910f25c784ccf9ec1fa719d1f9"},
+]
+
+[package.dependencies]
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "charset-normalizer"
@@ -263,7 +377,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -335,7 +449,7 @@ version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
     {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
@@ -675,6 +789,21 @@ files = [
 ]
 
 [[package]]
+name = "outcome"
+version = "1.3.0.post0"
+description = "Capture the outcome of Python function calls."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "outcome-1.3.0.post0-py2.py3-none-any.whl", hash = "sha256:e771c5ce06d1415e356078d3bdd68523f284b4ce5419828922b6871e65eda82b"},
+    {file = "outcome-1.3.0.post0.tar.gz", hash = "sha256:9dcf02e65f2971b80047b377468e72a268e15c0af3cf1238e6ff14f7f91143b8"},
+]
+
+[package.dependencies]
+attrs = ">=19.2.0"
+
+[[package]]
 name = "packaging"
 version = "26.2"
 description = "Core utilities for Python packages"
@@ -962,6 +1091,19 @@ files = [
 ]
 
 [[package]]
+name = "pycparser"
+version = "3.0"
+description = "C parser in Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+markers = "os_name == \"nt\" and implementation_name != \"pypy\" and implementation_name != \"PyPy\""
+files = [
+    {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
+    {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
+]
+
+[[package]]
 name = "pydeck"
 version = "0.9.3"
 description = "Widget for deck.gl maps"
@@ -990,6 +1132,19 @@ python-versions = "*"
 groups = ["main"]
 files = [
     {file = "pydevd_pycharm-252.27397.106.tar.gz", hash = "sha256:10020b3a14517e5a02c5992b4cc6d9b4e8dc72f4777baf72aeed8423744ee484"},
+]
+
+[[package]]
+name = "pysocks"
+version = "1.7.1"
+description = "A Python SOCKS client module. See https://github.com/Anorov/PySocks for more information."
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+groups = ["dev"]
+files = [
+    {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},
+    {file = "PySocks-1.7.1-py3-none-any.whl", hash = "sha256:2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"},
+    {file = "PySocks-1.7.1.tar.gz", hash = "sha256:3f8804571ebe159c380ac6de37643bb4685970655d3bba243530d6558b799aa0"},
 ]
 
 [[package]]
@@ -1200,6 +1355,26 @@ files = [
 ]
 
 [[package]]
+name = "selenium"
+version = "4.46.0"
+description = "Official Python bindings for Selenium WebDriver"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "selenium-4.46.0-py3-none-any.whl", hash = "sha256:f03e864770a21ab32009961c9d015cb2c6275eba45c926c272e02d90af423aad"},
+    {file = "selenium-4.46.0.tar.gz", hash = "sha256:54f7e1a4df5f7508ac8c38ce2ea584db1b27083dd79962b22524219219df5cbe"},
+]
+
+[package.dependencies]
+certifi = ">=2026.2.25"
+trio = ">=0.31.0,<1.0"
+trio-websocket = ">=0.12.2,<1.0"
+typing_extensions = ">=4.15.0,<5.0"
+urllib3 = {version = ">=2.6.3,<3.0", extras = ["socks"]}
+websocket-client = ">=1.8.0,<2.0"
+
+[[package]]
 name = "six"
 version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
@@ -1221,6 +1396,30 @@ groups = ["main"]
 files = [
     {file = "smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f"},
     {file = "smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c"},
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+description = "Sniff out which async library your code is running under"
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
+    {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+groups = ["dev"]
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
 ]
 
 [[package]]
@@ -1318,12 +1517,49 @@ files = [
 ]
 
 [[package]]
+name = "trio"
+version = "0.33.0"
+description = "A friendly Python library for async concurrency and I/O"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "trio-0.33.0-py3-none-any.whl", hash = "sha256:3bd5d87f781d9b0192d592aef28691f8951d6c2e41b7e1da4c25cde6c180ae9b"},
+    {file = "trio-0.33.0.tar.gz", hash = "sha256:a29b92b73f09d4b48ed249acd91073281a7f1063f09caba5dc70465b5c7aa970"},
+]
+
+[package.dependencies]
+attrs = ">=23.2.0"
+cffi = {version = ">=1.14", markers = "os_name == \"nt\" and implementation_name != \"pypy\""}
+idna = "*"
+outcome = "*"
+sniffio = ">=1.3.0"
+sortedcontainers = "*"
+
+[[package]]
+name = "trio-websocket"
+version = "0.12.2"
+description = "WebSocket library for Trio"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "trio_websocket-0.12.2-py3-none-any.whl", hash = "sha256:df605665f1db533f4a386c94525870851096a223adcb97f72a07e8b4beba45b6"},
+    {file = "trio_websocket-0.12.2.tar.gz", hash = "sha256:22c72c436f3d1e264d0910a3951934798dcc5b00ae56fc4ee079d46c7cf20fae"},
+]
+
+[package.dependencies]
+outcome = ">=1.2.0"
+trio = ">=0.11"
+wsproto = ">=0.14"
+
+[[package]]
 name = "typing-extensions"
 version = "4.16.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"},
     {file = "typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5"},
@@ -1348,11 +1584,14 @@ version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
     {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
+
+[package.dependencies]
+pysocks = {version = ">=1.5.6,<1.5.7 || >1.5.7,<2.0", optional = true, markers = "extra == \"socks\""}
 
 [package.extras]
 brotli = ["brotli (>=1.2.0) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=1.2.0.0) ; platform_python_implementation != \"CPython\""]
@@ -1422,6 +1661,23 @@ files = [
 
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)"]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+description = "WebSocket client for Python with low level API options"
+optional = false
+python-versions = ">=3.9"
+groups = ["dev"]
+files = [
+    {file = "websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef"},
+    {file = "websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98"},
+]
+
+[package.extras]
+docs = ["Sphinx (>=6.0)", "myst-parser (>=2.0.0)", "sphinx_rtd_theme (>=1.1.0)"]
+optional = ["python-socks", "wsaccel"]
+test = ["pytest", "websockets"]
 
 [[package]]
 name = "websockets"
@@ -1542,7 +1798,22 @@ files = [
     {file = "websockets-16.1.tar.gz", hash = "sha256:299468cbe42e2b9981134c7c51d99387d8a7bf562b00183b3eec53f882846dad"},
 ]
 
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+description = "Pure-Python WebSocket protocol implementation"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584"},
+    {file = "wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294"},
+]
+
+[package.dependencies]
+h11 = ">=0.16.0,<1"
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "b5ffc8f51d5276be4c3fbf50d98166a2f012d1fb7a85ef467ff3f154b4ec74ec"
+content-hash = "51e6f8a8b81bb749a7fe9ea0005d715e2a5bab0d775d236b2efc370375a366c3"

--- a/webreport/frontend/pyproject.toml
+++ b/webreport/frontend/pyproject.toml
@@ -8,11 +8,14 @@ authors = [
 
 [tool.poetry.dependencies]
 python = ">=3.11"
-streamlit = ">=1.28.0"
+streamlit = ">=1.59.2"
 requests = ">=2.31.0"
 pandas = ">=2.0.0"
 python-dotenv = ">=1.0.0"
 pydevd-pycharm = "~=252.27397.106"
+
+[tool.poetry.group.dev.dependencies]
+selenium = "^4.46.0"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/webreport/frontend/report_pane.py
+++ b/webreport/frontend/report_pane.py
@@ -72,6 +72,8 @@ def _render_data(data: object) -> None:
             file_name=f"report_{datetime.now():%Y%m%d_%H%M%S}.csv",
             mime="text/csv",
         )
+        if dataframe.columns.empty:
+            return
         index_column = dataframe.columns[0]
         numeric_columns = [
             column

--- a/webreport/frontend/report_pane.py
+++ b/webreport/frontend/report_pane.py
@@ -57,13 +57,13 @@ def _render_data(data: object) -> None:
     if isinstance(data, list) and data:
         dataframe = pd.DataFrame(data)
         st.markdown("#### Основные показатели")
-        total, points, dates = st.columns(3)
+        total, points, columns_count = st.columns(3)
         with total:
             st.metric("Всего записей", len(dataframe))
         with points:
             if "total_points" in dataframe.columns:
                 st.metric("Средние очки", f"{dataframe['total_points'].mean():.2f}")
-        with dates:
+        with columns_count:
             st.metric("Колонок", len(dataframe.columns))
         st.dataframe(dataframe, use_container_width=True, height=320)
         st.download_button(

--- a/webreport/frontend/report_pane.py
+++ b/webreport/frontend/report_pane.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from datetime import datetime
+
+import pandas as pd
+import streamlit as st
+
+
+def render_report_pane(refresh: Callable[[], None]) -> None:
+    header, refresh_action, fullscreen = st.columns([8, 1, 1])
+    with header:
+        st.subheader("📊 Отчёт")
+    with refresh_action:
+        if st.button("⟳", key="refresh_report", help="Обновить страницу"):
+            refresh()
+    with fullscreen:
+        if st.button("⛶", key="fullscreen_report", help="Развернуть отчёт"):
+            st.session_state.fullscreen = None if st.session_state.fullscreen == "report" else "report"
+            st.rerun()
+
+    with st.container(height=520, key="report-pane-scroll", border=False):
+        report = _active_report()
+        if report is None:
+            st.info("Отчёт появится здесь сразу после ответа агента.")
+            st.markdown("""
+            Примеры запросов:
+            - все игры;
+            - топ 10 команд по очкам;
+            - статистика команды.
+            """)
+            return
+        st.caption(f"Запрос: {report['request_text']}")
+        st.markdown(f"### {report['title']}")
+        if st.session_state.is_generating:
+            st.markdown(
+                """
+                <div class="report-loading-overlay">
+                    <div class="report-loading-spinner"></div>
+                    <strong>Генерируем новый отчёт</strong>
+                </div>
+                """,
+                unsafe_allow_html=True,
+            )
+        _render_data(report["data"])
+
+
+def _active_report() -> dict[str, object] | None:
+    for message in st.session_state.chat_history:
+        report = message.get("report")
+        if isinstance(report, dict) and report.get("id") == st.session_state.active_report_id:
+            return report
+    return None
+
+
+def _render_data(data: object) -> None:
+    if isinstance(data, list) and data:
+        dataframe = pd.DataFrame(data)
+        st.markdown("#### Основные показатели")
+        total, points, dates = st.columns(3)
+        with total:
+            st.metric("Всего записей", len(dataframe))
+        with points:
+            if "total_points" in dataframe.columns:
+                st.metric("Средние очки", f"{dataframe['total_points'].mean():.2f}")
+        with dates:
+            st.metric("Колонок", len(dataframe.columns))
+        st.dataframe(dataframe, use_container_width=True, height=320)
+        st.download_button(
+            "Скачать CSV",
+            data=dataframe.to_csv(index=False).encode("utf-8"),
+            file_name=f"report_{datetime.now():%Y%m%d_%H%M%S}.csv",
+            mime="text/csv",
+        )
+        index_column = dataframe.columns[0]
+        numeric_columns = [
+            column
+            for column in dataframe.select_dtypes(include=["float64", "int64"]).columns.tolist()
+            if column != index_column
+        ]
+        if numeric_columns:
+            chart_column = st.selectbox("Колонка для графика", numeric_columns)
+            st.bar_chart(dataframe.set_index(index_column)[chart_column])
+        return
+    if isinstance(data, dict):
+        st.json(data)
+        return
+    st.write(data)

--- a/webreport/frontend/split_pane.py
+++ b/webreport/frontend/split_pane.py
@@ -224,7 +224,6 @@ export default function({ parentElement, data, setTriggerValue }) {
   justify-content: center;
   min-width: 22px;
   overflow: hidden;
-  resize: horizontal;
   transition: background-color 120ms ease;
 }
 .split-pane-divider:hover,

--- a/webreport/frontend/split_pane.py
+++ b/webreport/frontend/split_pane.py
@@ -53,6 +53,7 @@ export default function({ parentElement, data, setTriggerValue }) {
     divider.className = "split-pane-divider";
     divider.setAttribute("aria-label", "Изменить ширину панелей");
     divider.setAttribute("role", "separator");
+    divider.setAttribute("aria-orientation", "vertical");
     divider.tabIndex = 0;
     divider.innerHTML = "<span></span><span></span><span></span>";
     reportColumn.before(divider);

--- a/webreport/frontend/split_pane.py
+++ b/webreport/frontend/split_pane.py
@@ -55,7 +55,6 @@ export default function({ parentElement, data, setTriggerValue }) {
     divider.setAttribute("aria-label", "Изменить ширину панелей");
     divider.setAttribute("role", "separator");
     divider.setAttribute("aria-orientation", "vertical");
-    divider.tabIndex = 0;
     divider.innerHTML = "<span></span><span></span><span></span>";
     reportColumn.before(divider);
     return divider;

--- a/webreport/frontend/split_pane.py
+++ b/webreport/frontend/split_pane.py
@@ -226,8 +226,7 @@ export default function({ parentElement, data, setTriggerValue }) {
   overflow: hidden;
   transition: background-color 120ms ease;
 }
-.split-pane-divider:hover,
-.split-pane-divider:focus-visible {
+.split-pane-divider:hover {
   background: rgba(30, 136, 229, 0.28);
   outline: none;
 }

--- a/webreport/frontend/split_pane.py
+++ b/webreport/frontend/split_pane.py
@@ -24,6 +24,7 @@ export default function({ parentElement, data, setTriggerValue }) {
   state.emit = setTriggerValue;
 
   const setStyle = (element, property, value) => {
+    if (!element) return;
     if (value === null) {
       element.style.removeProperty(property);
       return;

--- a/webreport/frontend/split_pane.py
+++ b/webreport/frontend/split_pane.py
@@ -85,10 +85,10 @@ export default function({ parentElement, data, setTriggerValue }) {
     row.style.alignItems = "stretch";
     row.style.flexWrap = "nowrap";
     row.style.gap = "0";
-    setStyle(chatPane, "height", stacked ? `${chatPaneHeight}px` : null);
-    setStyle(reportPane, "height", stacked ? `${reportPaneHeight}px` : null);
-    setStyle(chatPane, "max-height", stacked ? `${chatPaneHeight}px` : null);
-    setStyle(reportPane, "max-height", stacked ? `${reportPaneHeight}px` : null);
+    setStyle(chatPane, "height", `${chatPaneHeight}px`);
+    setStyle(reportPane, "height", `${reportPaneHeight}px`);
+    setStyle(chatPane, "max-height", `${chatPaneHeight}px`);
+    setStyle(reportPane, "max-height", `${reportPaneHeight}px`);
 
     if (stacked) {
       divider.style.display = "none";

--- a/webreport/frontend/split_pane.py
+++ b/webreport/frontend/split_pane.py
@@ -10,6 +10,7 @@ from streamlit.components.v2 import component
 
 CONTROLLER_KEY: Final = "split_pane_controller"
 _MINIMUM_PANE_WIDTH: Final = 20.0
+_MAXIMUM_PANE_WIDTH: Final = 100.0 - _MINIMUM_PANE_WIDTH
 
 _SPLIT_PANE_CONTROLLER = component(
     "split_pane_controller",
@@ -259,7 +260,7 @@ def _save_split_position() -> None:
     position = event.get("position_pct")
     if isinstance(position, bool) or not isinstance(position, (int, float)):
         return
-    st.session_state.split_pct = min(80.0, max(_MINIMUM_PANE_WIDTH, float(position)))
+    st.session_state.split_pct = min(_MAXIMUM_PANE_WIDTH, max(_MINIMUM_PANE_WIDTH, float(position)))
     st.session_state.user_has_dragged = True
 
 

--- a/webreport/frontend/split_pane.py
+++ b/webreport/frontend/split_pane.py
@@ -61,6 +61,15 @@ export default function({ parentElement, data, setTriggerValue }) {
 
   const clamp = (value) => Math.min(100 - %MINIMUM_PANE_WIDTH%, Math.max(%MINIMUM_PANE_WIDTH%, value));
   const isStacked = () => window.matchMedia("(max-width: 768px)").matches;
+  const minimumViewportHeight = 320;
+  const minimumStackedPaneHeight = 230;
+  const minimumChatPaneHeight = 96;
+  const minimumReportPaneHeight = 160;
+
+  const chromeHeight = (pane, column) => {
+    if (!pane) return 0;
+    return Math.max(0, Math.round(pane.getBoundingClientRect().top - column.getBoundingClientRect().top));
+  };
 
   const applySplit = (position) => {
     const current = layout();
@@ -72,10 +81,10 @@ export default function({ parentElement, data, setTriggerValue }) {
     const chatPane = documentRoot.querySelector(".st-key-chat-pane-scroll");
     const reportPane = documentRoot.querySelector(".st-key-report-pane-scroll");
     const loadingOverlay = documentRoot.querySelector(".report-loading-overlay");
-    const viewportHeight = Math.max(320, window.innerHeight - 118);
-    const paneHeight = stacked ? Math.max(230, Math.floor(viewportHeight / 2) - 8) : viewportHeight;
-    const chatPaneHeight = Math.max(96, paneHeight - 240);
-    const reportPaneHeight = Math.max(160, paneHeight - 112);
+    const viewportHeight = Math.max(minimumViewportHeight, Math.floor(window.innerHeight - row.getBoundingClientRect().top));
+    const paneHeight = stacked ? Math.max(minimumStackedPaneHeight, Math.floor(viewportHeight / 2)) : viewportHeight;
+    const chatPaneHeight = Math.max(minimumChatPaneHeight, paneHeight - chromeHeight(chatPane, chatColumn));
+    const reportPaneHeight = Math.max(minimumReportPaneHeight, paneHeight - chromeHeight(reportPane, reportColumn));
 
     row.style.display = "flex";
     row.style.height = `${viewportHeight}px`;

--- a/webreport/frontend/split_pane.py
+++ b/webreport/frontend/split_pane.py
@@ -1,0 +1,277 @@
+"""Browser-side controls for the Streamlit split-pane layout."""
+
+from __future__ import annotations
+
+from typing import Final, TypeGuard
+
+import streamlit as st
+from streamlit.components.v2 import component
+
+
+CONTROLLER_KEY: Final = "split_pane_controller"
+_MINIMUM_PANE_WIDTH: Final = 20.0
+
+_SPLIT_PANE_CONTROLLER = component(
+    "split_pane_controller",
+    html="<div aria-hidden=\"true\"></div>",
+    js="""
+export default function({ parentElement, data, setTriggerValue }) {
+  const documentRoot = parentElement.ownerDocument;
+  const stateKey = "__gameReportSplitPane";
+  const state = documentRoot[stateKey] ?? {};
+  documentRoot[stateKey] = state;
+  state.data = data;
+  state.emit = setTriggerValue;
+
+  const setStyle = (element, property, value) => {
+    if (value === null) {
+      element.style.removeProperty(property);
+      return;
+    }
+    element.style.setProperty(property, value, "important");
+  };
+
+  const anchors = () => ({
+    chat: documentRoot.getElementById("chat-pane-anchor"),
+    report: documentRoot.getElementById("report-pane-anchor"),
+  });
+
+  const layout = () => {
+    const { chat, report } = anchors();
+    if (!chat || !report) return null;
+    const chatColumn = chat.closest('[data-testid="stColumn"]');
+    const reportColumn = report.closest('[data-testid="stColumn"]');
+    if (!chatColumn || !reportColumn) return null;
+    return { chatColumn, reportColumn, row: chatColumn.parentElement };
+  };
+
+  const ensureDivider = (row, reportColumn) => {
+    let divider = row.querySelector(".split-pane-divider");
+    if (divider) return divider;
+    divider = documentRoot.createElement("div");
+    divider.className = "split-pane-divider";
+    divider.setAttribute("aria-label", "Изменить ширину панелей");
+    divider.setAttribute("role", "separator");
+    divider.tabIndex = 0;
+    divider.innerHTML = "<span></span><span></span><span></span>";
+    reportColumn.before(divider);
+    return divider;
+  };
+
+  const clamp = (value) => Math.min(100 - %MINIMUM_PANE_WIDTH%, Math.max(%MINIMUM_PANE_WIDTH%, value));
+  const isStacked = () => window.matchMedia("(max-width: 768px)").matches;
+
+  const applySplit = (position) => {
+    const current = layout();
+    if (!current || !current.row) return;
+    const { chatColumn, reportColumn, row } = current;
+    const divider = ensureDivider(row, reportColumn);
+    const stacked = isStacked();
+    const fullscreen = state.data.fullscreen;
+    const chatPane = documentRoot.querySelector(".st-key-chat-pane-scroll");
+    const reportPane = documentRoot.querySelector(".st-key-report-pane-scroll");
+    const loadingOverlay = documentRoot.querySelector(".report-loading-overlay");
+    const viewportHeight = Math.max(320, window.innerHeight - 118);
+    const paneHeight = stacked ? Math.max(230, Math.floor(viewportHeight / 2) - 8) : viewportHeight;
+    const chatPaneHeight = Math.max(96, paneHeight - 240);
+    const reportPaneHeight = Math.max(160, paneHeight - 112);
+
+    row.style.display = "flex";
+    row.style.height = `${viewportHeight}px`;
+    row.style.maxHeight = `${viewportHeight}px`;
+    row.style.overflow = "hidden";
+    row.style.flexDirection = stacked ? "column-reverse" : "row";
+    row.style.alignItems = "stretch";
+    row.style.flexWrap = "nowrap";
+    row.style.gap = "0";
+    setStyle(chatPane, "height", stacked ? `${chatPaneHeight}px` : null);
+    setStyle(reportPane, "height", stacked ? `${reportPaneHeight}px` : null);
+    setStyle(chatPane, "max-height", stacked ? `${chatPaneHeight}px` : null);
+    setStyle(reportPane, "max-height", stacked ? `${reportPaneHeight}px` : null);
+
+    if (stacked) {
+      divider.style.display = "none";
+      setStyle(chatColumn, "flex", "0 0 auto");
+      setStyle(reportColumn, "flex", "0 0 auto");
+      setStyle(chatColumn, "height", `${paneHeight}px`);
+      setStyle(reportColumn, "height", `${paneHeight}px`);
+      setStyle(chatColumn, "max-height", `${paneHeight}px`);
+      setStyle(reportColumn, "max-height", `${paneHeight}px`);
+      setStyle(chatColumn, "overflow", "hidden");
+      setStyle(reportColumn, "overflow", "hidden");
+      setStyle(chatColumn, "width", "100%");
+      setStyle(reportColumn, "width", "100%");
+    } else {
+      divider.style.display = "flex";
+      setStyle(chatColumn, "height", null);
+      setStyle(reportColumn, "height", null);
+      setStyle(chatColumn, "max-height", null);
+      setStyle(reportColumn, "max-height", null);
+      setStyle(chatColumn, "overflow", null);
+      setStyle(reportColumn, "overflow", null);
+      setStyle(chatColumn, "flex", `0 0 ${position}%`);
+      setStyle(reportColumn, "flex", `1 1 ${100 - position}%`);
+      setStyle(chatColumn, "width", `${position}%`);
+      setStyle(reportColumn, "width", `${100 - position}%`);
+    }
+
+    const header = documentRoot.querySelector('[data-testid="stHeader"]');
+    if (fullscreen === "chat" || fullscreen === "report") {
+      const visibleColumn = fullscreen === "chat" ? chatColumn : reportColumn;
+      const hiddenColumn = fullscreen === "chat" ? reportColumn : chatColumn;
+      hiddenColumn.style.display = "none";
+      setStyle(visibleColumn, "display", "block");
+      setStyle(visibleColumn, "flex", "1 1 100%");
+      setStyle(visibleColumn, "width", "100%");
+      row.style.position = "fixed";
+      row.style.inset = "0";
+      row.style.zIndex = "1000000";
+      row.style.height = "100dvh";
+      row.style.maxHeight = "100dvh";
+      if (header) header.style.display = "none";
+      const fullscreenPane = fullscreen === "chat" ? chatPane : reportPane;
+      setStyle(fullscreenPane, "height", "100dvh");
+      setStyle(fullscreenPane, "max-height", "100dvh");
+    } else {
+      chatColumn.style.removeProperty("display");
+      reportColumn.style.removeProperty("display");
+      row.style.removeProperty("position");
+      row.style.removeProperty("inset");
+      row.style.removeProperty("z-index");
+      if (header) header.style.removeProperty("display");
+    }
+
+    if (loadingOverlay && reportPane) {
+      const bounds = reportPane.getBoundingClientRect();
+      loadingOverlay.style.position = "fixed";
+      loadingOverlay.style.left = `${bounds.left}px`;
+      loadingOverlay.style.top = `${bounds.top}px`;
+      loadingOverlay.style.width = `${bounds.width}px`;
+      loadingOverlay.style.height = `${bounds.height}px`;
+    }
+  };
+
+  const current = layout();
+  if (current && current.row) {
+    const divider = ensureDivider(current.row, current.reportColumn);
+    if (!divider.dataset.splitPaneBound) {
+      divider.dataset.splitPaneBound = "true";
+      divider.addEventListener("pointerdown", (event) => {
+        if (isStacked()) return;
+        event.preventDefault();
+        divider.setPointerCapture(event.pointerId);
+        const move = (moveEvent) => {
+          const activeLayout = layout();
+          if (!activeLayout || !activeLayout.row) return;
+          const bounds = activeLayout.row.getBoundingClientRect();
+          const next = clamp(((moveEvent.clientX - bounds.left) / bounds.width) * 100);
+          state.preview = next;
+          applySplit(next);
+        };
+        const release = (releaseEvent) => {
+          move(releaseEvent);
+          divider.releasePointerCapture(releaseEvent.pointerId);
+          divider.removeEventListener("pointermove", move);
+          divider.removeEventListener("pointerup", release);
+          state.emit("divider_released", {
+            position_pct: state.preview ?? state.data.split_pct,
+            released_at: Date.now(),
+          });
+        };
+        divider.addEventListener("pointermove", move);
+        divider.addEventListener("pointerup", release, { once: true });
+      });
+    }
+  }
+
+  if (!state.escapeListener) {
+    state.escapeListener = (event) => {
+      if (event.key === "Escape" && state.data.fullscreen) {
+        state.emit("escape", { released_at: Date.now() });
+      }
+    };
+    documentRoot.addEventListener("keydown", state.escapeListener);
+    window.addEventListener("resize", () => applySplit(state.data.split_pct));
+  }
+
+  documentRoot.documentElement.style.overflow = "hidden";
+  documentRoot.body.style.overflow = "hidden";
+  requestAnimationFrame(() => applySplit(state.data.split_pct));
+}
+""".replace("%MINIMUM_PANE_WIDTH%", str(_MINIMUM_PANE_WIDTH)),
+    css="""
+.split-pane-divider {
+  align-items: center;
+  background: rgba(30, 136, 229, 0.14);
+  border-left: 1px solid rgba(30, 136, 229, 0.5);
+  border-right: 1px solid rgba(30, 136, 229, 0.5);
+  cursor: ew-resize;
+  display: flex;
+  flex: 0 0 22px;
+  flex-direction: column;
+  gap: 4px;
+  justify-content: center;
+  min-width: 22px;
+  overflow: hidden;
+  resize: horizontal;
+  transition: background-color 120ms ease;
+}
+.split-pane-divider:hover,
+.split-pane-divider:focus-visible {
+  background: rgba(30, 136, 229, 0.28);
+  outline: none;
+}
+.split-pane-divider span {
+  background: #1E88E5;
+  border-radius: 999px;
+  height: 5px;
+  opacity: 0.9;
+  width: 5px;
+}
+""",
+    isolate_styles=False,
+)
+
+
+def _controller_value(event_name: str) -> object:
+    controller_state = st.session_state.get(CONTROLLER_KEY)
+    return getattr(controller_state, event_name, None)
+
+
+def _is_object_map(value: object) -> TypeGuard[dict[str, object]]:
+    return isinstance(value, dict)
+
+
+def _save_split_position() -> None:
+    event = _controller_value("divider_released")
+    if not _is_object_map(event):
+        return
+    position = event.get("position_pct")
+    if isinstance(position, bool) or not isinstance(position, (int, float)):
+        return
+    st.session_state.split_pct = min(80.0, max(_MINIMUM_PANE_WIDTH, float(position)))
+    st.session_state.user_has_dragged = True
+
+
+def _exit_fullscreen() -> None:
+    if _controller_value("escape") is not None:
+        st.session_state.fullscreen = None
+
+
+def render_split_pane_controller(
+    split_pct: float,
+    fullscreen: str | None,
+    is_generating: bool,
+) -> None:
+    """Synchronize the browser-side divider and fullscreen keyboard shortcut."""
+    _ = _SPLIT_PANE_CONTROLLER(
+        key=CONTROLLER_KEY,
+        data={
+            "split_pct": split_pct,
+            "fullscreen": fullscreen,
+            "is_generating": is_generating,
+        },
+        height=0,
+        on_divider_released_change=_save_split_position,
+        on_escape_change=_exit_fullscreen,
+    )

--- a/webreport/frontend/test_report_pane.py
+++ b/webreport/frontend/test_report_pane.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+import report_pane
+
+
+class _Container:
+    def __enter__(self) -> _Container:
+        return self
+
+    def __exit__(self, exception_type: object, exception: object, traceback: object) -> bool:
+        return False
+
+
+class _Streamlit:
+    def __init__(self) -> None:
+        self.bar_chart_calls: int = 0
+        self.session_state: object = type(
+            "SessionState",
+            (),
+            {
+                "active_report_id": "report",
+                "chat_history": [
+                    {
+                        "report": {
+                            "id": "report",
+                            "request_text": "пустой отчёт",
+                            "title": "Пустой отчёт",
+                            "data": [{}],
+                        }
+                    }
+                ],
+                "fullscreen": None,
+                "is_generating": False,
+            },
+        )()
+
+    def subheader(self, _body: str) -> None:
+        return None
+
+    def markdown(self, _body: str) -> None:
+        return None
+
+    def columns(self, _count: object) -> tuple[_Container, _Container, _Container]:
+        return (_Container(), _Container(), _Container())
+
+    def button(self, _label: str, **_kwargs: object) -> bool:
+        return False
+
+    def rerun(self) -> None:
+        return None
+
+    def container(self, **_kwargs: object) -> _Container:
+        return _Container()
+
+    def info(self, _body: str) -> None:
+        return None
+
+    def caption(self, _body: str) -> None:
+        return None
+
+    def metric(self, _label: str, _value: object) -> None:
+        return None
+
+    def dataframe(self, _data: object, **_kwargs: object) -> None:
+        return None
+
+    def download_button(self, _label: str, **_kwargs: object) -> None:
+        return None
+
+    def bar_chart(self, _data: object) -> None:
+        self.bar_chart_calls += 1
+
+
+class RenderDataTest(unittest.TestCase):
+    def test_skips_chart_when_records_have_no_columns(self) -> None:
+        streamlit = _Streamlit()
+
+        with patch.object(report_pane, "st", streamlit):
+            report_pane.render_report_pane(lambda: None)
+
+        self.assertEqual(0, streamlit.bar_chart_calls)
+
+
+if __name__ == "__main__":
+    _ = unittest.main()

--- a/webreport/frontend/test_report_render.py
+++ b/webreport/frontend/test_report_render.py
@@ -99,6 +99,30 @@ class ReportRenderTest(unittest.TestCase):
         ]
         self.assertEqual([], console_errors)
 
+    def test_desktop_split_pane_sets_scroll_pane_heights(self) -> None:
+        original_size = self.driver.get_window_size()
+        self.driver.set_window_size(1280, 720)
+        try:
+            self.driver.get(FRONTEND_URL)
+            self.wait.until(
+                lambda driver: driver.find_element(By.CSS_SELECTOR, ".st-key-chat-pane-scroll")
+            )
+            self.driver.execute_async_script(
+                "const done = arguments[arguments.length - 1]; requestAnimationFrame(done);"
+            )
+            pane_heights = self.driver.execute_script(
+                """
+                return [
+                    document.querySelector(".st-key-chat-pane-scroll").style.height,
+                    document.querySelector(".st-key-report-pane-scroll").style.height,
+                ];
+                """
+            )
+        finally:
+            self.driver.set_window_size(original_size["width"], original_size["height"])
+
+        self.assertTrue(all(isinstance(height, str) and height.endswith("px") for height in pane_heights))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/webreport/frontend/test_report_render.py
+++ b/webreport/frontend/test_report_render.py
@@ -105,7 +105,13 @@ class ReportRenderTest(unittest.TestCase):
         try:
             self.driver.get(FRONTEND_URL)
             self.wait.until(
-                lambda driver: driver.find_element(By.CSS_SELECTOR, ".st-key-chat-pane-scroll")
+                lambda driver: all(
+                    driver.find_elements(By.CSS_SELECTOR, selector)
+                    for selector in (
+                        ".st-key-chat-pane-scroll",
+                        ".st-key-report-pane-scroll",
+                    )
+                )
             )
             self.driver.execute_async_script(
                 "const done = arguments[arguments.length - 1]; requestAnimationFrame(done);"

--- a/webreport/frontend/test_report_render.py
+++ b/webreport/frontend/test_report_render.py
@@ -74,6 +74,31 @@ class ReportRenderTest(unittest.TestCase):
         ]
         self.assertEqual([], console_errors)
 
+    def test_split_pane_tolerates_missing_scroll_panes_during_rerender(self) -> None:
+        self.driver.get(FRONTEND_URL)
+        self.wait.until(
+            lambda driver: driver.find_element(By.CSS_SELECTOR, "textarea[aria-label='Ваше сообщение']")
+        )
+        self.driver.get_log("browser")
+
+        self.driver.execute_script(
+            """
+            document.querySelector(".st-key-chat-pane-scroll").classList.remove("st-key-chat-pane-scroll");
+            document.querySelector(".st-key-report-pane-scroll").classList.remove("st-key-report-pane-scroll");
+            window.dispatchEvent(new Event("resize"));
+            """
+        )
+        self.driver.execute_async_script(
+            "const done = arguments[arguments.length - 1]; requestAnimationFrame(done);"
+        )
+
+        console_errors = [
+            entry
+            for entry in self.driver.get_log("browser")
+            if entry["level"] == "SEVERE"
+        ]
+        self.assertEqual([], console_errors)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/webreport/frontend/test_report_render.py
+++ b/webreport/frontend/test_report_render.py
@@ -113,6 +113,10 @@ class ReportRenderTest(unittest.TestCase):
                     )
                 )
             )
+            divider = self.wait.until(
+                expected.presence_of_element_located((By.CSS_SELECTOR, ".split-pane-divider"))
+            )
+            self.assertEqual("vertical", divider.get_attribute("aria-orientation"))
             self.driver.execute_async_script(
                 "const done = arguments[arguments.length - 1]; requestAnimationFrame(done);"
             )

--- a/webreport/frontend/test_report_render.py
+++ b/webreport/frontend/test_report_render.py
@@ -117,6 +117,7 @@ class ReportRenderTest(unittest.TestCase):
                 expected.presence_of_element_located((By.CSS_SELECTOR, ".split-pane-divider"))
             )
             self.assertEqual("vertical", divider.get_attribute("aria-orientation"))
+            self.assertIsNone(divider.get_attribute("tabindex"))
             self.assertEqual("none", divider.value_of_css_property("resize"))
             self.driver.execute_async_script(
                 "const done = arguments[arguments.length - 1]; requestAnimationFrame(done);"

--- a/webreport/frontend/test_report_render.py
+++ b/webreport/frontend/test_report_render.py
@@ -117,6 +117,7 @@ class ReportRenderTest(unittest.TestCase):
                 expected.presence_of_element_located((By.CSS_SELECTOR, ".split-pane-divider"))
             )
             self.assertEqual("vertical", divider.get_attribute("aria-orientation"))
+            self.assertEqual("none", divider.value_of_css_property("resize"))
             self.driver.execute_async_script(
                 "const done = arguments[arguments.length - 1]; requestAnimationFrame(done);"
             )

--- a/webreport/frontend/test_report_render.py
+++ b/webreport/frontend/test_report_render.py
@@ -110,18 +110,29 @@ class ReportRenderTest(unittest.TestCase):
             self.driver.execute_async_script(
                 "const done = arguments[arguments.length - 1]; requestAnimationFrame(done);"
             )
-            pane_heights = self.driver.execute_script(
+            pane_sizes = self.driver.execute_script(
                 """
-                return [
-                    document.querySelector(".st-key-chat-pane-scroll").style.height,
-                    document.querySelector(".st-key-report-pane-scroll").style.height,
-                ];
+                const chatPane = document.querySelector(".st-key-chat-pane-scroll");
+                const reportPane = document.querySelector(".st-key-report-pane-scroll");
+                const chatColumn = chatPane.closest('[data-testid="stColumn"]');
+                const reportColumn = reportPane.closest('[data-testid="stColumn"]');
+                const row = chatColumn.parentElement;
+                const availableHeight = Math.max(320, Math.floor(window.innerHeight - row.getBoundingClientRect().top));
+                const chatChrome = Math.round(chatPane.getBoundingClientRect().top - chatColumn.getBoundingClientRect().top);
+                const reportChrome = Math.round(reportPane.getBoundingClientRect().top - reportColumn.getBoundingClientRect().top);
+                return {
+                    actual: [chatPane.style.height, reportPane.style.height],
+                    expected: [
+                        `${Math.max(96, availableHeight - chatChrome)}px`,
+                        `${Math.max(160, availableHeight - reportChrome)}px`,
+                    ],
+                };
                 """
             )
         finally:
             self.driver.set_window_size(original_size["width"], original_size["height"])
 
-        self.assertTrue(all(isinstance(height, str) and height.endswith("px") for height in pane_heights))
+        self.assertEqual(pane_sizes["expected"], pane_sizes["actual"])
 
 
 if __name__ == "__main__":

--- a/webreport/frontend/test_report_render.py
+++ b/webreport/frontend/test_report_render.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import os
+import unittest
+
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as expected
+from selenium.webdriver.support.ui import WebDriverWait
+
+
+FRONTEND_URL = os.getenv("WEBREPORT_FRONTEND_URL", "http://127.0.0.1:28501")
+
+
+class ReportRenderTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        options = Options()
+        options.add_argument("--headless=new")
+        options.add_argument("--no-sandbox")
+        options.add_argument("--disable-dev-shm-usage")
+        options.set_capability("goog:loggingPrefs", {"browser": "ALL"})
+        cls.driver = webdriver.Chrome(options=options)
+        cls.wait = WebDriverWait(cls.driver, 15)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.driver.quit()
+
+    def test_report_renders_without_traceback_or_console_errors(self) -> None:
+        self.driver.get(FRONTEND_URL)
+        self.wait.until(
+            lambda driver: driver.find_element(By.CSS_SELECTOR, "textarea[aria-label='Ваше сообщение']")
+        ).send_keys("покажи все игры")
+        self.driver.find_element(By.XPATH, "//button[normalize-space()='Отправить']").click()
+
+        self.wait.until(
+            expected.visibility_of_element_located(
+                (By.XPATH, "//*[normalize-space()='Основные показатели']")
+            )
+        )
+        report_pane = self.driver.find_element(By.CSS_SELECTOR, ".st-key-report-pane-scroll")
+        self.assertIn("Запрос: покажи все игры", report_pane.text)
+
+        self.assertEqual([], self.driver.find_elements(By.XPATH, "//*[normalize-space()='Traceback']"))
+        console_errors = [
+            entry
+            for entry in self.driver.get_log("browser")
+            if entry["level"] == "SEVERE"
+        ]
+        self.assertEqual([], console_errors)
+
+    def test_top_teams_report_renders_without_traceback_or_console_errors(self) -> None:
+        self.driver.get(FRONTEND_URL)
+        self.wait.until(
+            lambda driver: driver.find_element(By.CSS_SELECTOR, "textarea[aria-label='Ваше сообщение']")
+        ).send_keys("топ 10 команд")
+        self.driver.find_element(By.XPATH, "//button[normalize-space()='Отправить']").click()
+
+        self.wait.until(
+            expected.visibility_of_element_located(
+                (By.XPATH, "//*[normalize-space()='Основные показатели']")
+            )
+        )
+        report_pane = self.driver.find_element(By.CSS_SELECTOR, ".st-key-report-pane-scroll")
+        self.assertIn("Запрос: топ 10 команд", report_pane.text)
+        self.assertIn("Скачать CSV", report_pane.text)
+        self.assertEqual([], self.driver.find_elements(By.XPATH, "//*[normalize-space()='Traceback']"))
+        console_errors = [
+            entry
+            for entry in self.driver.get_log("browser")
+            if entry["level"] == "SEVERE"
+        ]
+        self.assertEqual([], console_errors)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webreport/frontend/test_report_render.py
+++ b/webreport/frontend/test_report_render.py
@@ -83,8 +83,8 @@ class ReportRenderTest(unittest.TestCase):
 
         self.driver.execute_script(
             """
-            document.querySelector(".st-key-chat-pane-scroll").classList.remove("st-key-chat-pane-scroll");
-            document.querySelector(".st-key-report-pane-scroll").classList.remove("st-key-report-pane-scroll");
+            document.querySelector(".st-key-chat-pane-scroll")?.classList.remove("st-key-chat-pane-scroll");
+            document.querySelector(".st-key-report-pane-scroll")?.classList.remove("st-key-report-pane-scroll");
             window.dispatchEvent(new Event("resize"));
             """
         )
@@ -109,6 +109,16 @@ class ReportRenderTest(unittest.TestCase):
             )
             self.driver.execute_async_script(
                 "const done = arguments[arguments.length - 1]; requestAnimationFrame(done);"
+            )
+            self.wait.until(
+                lambda driver: driver.execute_script(
+                    """
+                    return [
+                        document.querySelector(".st-key-chat-pane-scroll"),
+                        document.querySelector(".st-key-report-pane-scroll"),
+                    ].every((pane) => pane?.style.height.endsWith("px"));
+                    """
+                )
             )
             pane_sizes = self.driver.execute_script(
                 """

--- a/webreport/frontend/test_send_chat_message.py
+++ b/webreport/frontend/test_send_chat_message.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+import unittest
+from unittest.mock import patch
+
+import requests
+
+import main
+
+
+class _InvalidJsonResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> object:
+        raise requests.exceptions.JSONDecodeError("invalid", "", 0)
+
+
+class SendChatMessageTest(unittest.TestCase):
+    def test_returns_user_friendly_error_when_backend_returns_invalid_json(self) -> None:
+        with (
+            patch.object(main, "st", SimpleNamespace(session_state=SimpleNamespace(session_id="test"))),
+            patch("main.requests.post", return_value=_InvalidJsonResponse()),
+        ):
+            result = main.send_chat_message("покажи все игры")
+
+        self.assertEqual(
+            {
+                "success": False,
+                "error": "Сервер вернул некорректный ответ.",
+                "message": "Сервер вернул некорректный ответ.",
+            },
+            result,
+        )
+
+
+if __name__ == "__main__":
+    _ = unittest.main()

--- a/webreport/frontend/test_send_chat_message.py
+++ b/webreport/frontend/test_send_chat_message.py
@@ -17,11 +17,35 @@ class _InvalidJsonResponse:
         raise requests.exceptions.JSONDecodeError("invalid", "", 0)
 
 
+class _ListJsonResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> object:
+        return ["unexpected"]
+
+
 class SendChatMessageTest(unittest.TestCase):
     def test_returns_user_friendly_error_when_backend_returns_invalid_json(self) -> None:
         with (
             patch.object(main, "st", SimpleNamespace(session_state=SimpleNamespace(session_id="test"))),
             patch("main.requests.post", return_value=_InvalidJsonResponse()),
+        ):
+            result = main.send_chat_message("покажи все игры")
+
+        self.assertEqual(
+            {
+                "success": False,
+                "error": "Сервер вернул некорректный ответ.",
+                "message": "Сервер вернул некорректный ответ.",
+            },
+            result,
+        )
+
+    def test_returns_user_friendly_error_when_backend_returns_json_list(self) -> None:
+        with (
+            patch.object(main, "st", SimpleNamespace(session_state=SimpleNamespace(session_id="test"))),
+            patch("main.requests.post", return_value=_ListJsonResponse()),
         ):
             result = main.send_chat_message("покажи все игры")
 


### PR DESCRIPTION
## Summary

- Add a split-pane Streamlit interface with chat controls on the left and rendered AI reports on the right.
- Preserve report history and add fullscreen and resizable report-pane controls.
- Add Selenium browser regression coverage for rendered game and top-team reports.
- Fix fallback parsing for Russian `топ <N> команд` requests so they return rankings instead of a team-name error.

## Verification

- `poetry run python test_report_render.py`
- Backend agent module compilation inside the backend container.